### PR TITLE
[Feature] Add content to styles-section and other pages

### DIFF
--- a/components/ComponentExample/ComponentCode.tsx
+++ b/components/ComponentExample/ComponentCode.tsx
@@ -23,6 +23,7 @@ const Highlighter = ({
     }}
     // clear default styles to allow e.g. wrap
     codeTagProps={{ style: {} }}
+    wrapLongLines={true}
   >
     {children}
   </SyntaxHighlighter>

--- a/components/ComponentExample/ComponentExample.tsx
+++ b/components/ComponentExample/ComponentExample.tsx
@@ -49,33 +49,26 @@ const ComponentExample: React.FunctionComponent<ComponentExampleProps> = ({
   return (
     <>
       {showcase}
-      {!noCode && (
-        <>
-          <Expander className="mt-l mb-l">
-            <ExpanderTitleButton>Koodiesimerkki (React)</ExpanderTitleButton>
-            <ExpanderContent>
-              {codeString ? (
-                <ComponentCode codeString={codeString} />
-              ) : (
-                getWithoutWrappers(children).map((child, index) => (
-                  <ComponentCode
-                    key={index}
-                    filterProps={filterPropsInExample}
-                    style={{
-                      paddingTop: index === 0 && !codeString ? '1rem' : 0,
-                      maxWidth: '700px',
-                    }}
-                  >
-                    {child}
-                  </ComponentCode>
-                ))
-              )}
-            </ExpanderContent>
-          </Expander>
-
-          <div className={styles.divider}></div>
-        </>
-      )}
+      <Expander className="mt-l mb-l">
+        <ExpanderTitleButton>Koodiesimerkki (React)</ExpanderTitleButton>
+        <ExpanderContent>
+          {codeString ? (
+            <ComponentCode codeString={codeString} />
+          ) : (
+            getWithoutWrappers(children).map((child, index) => (
+              <ComponentCode
+                key={index}
+                filterProps={filterPropsInExample}
+                style={{
+                  paddingTop: index === 0 && !codeString ? '1rem' : 0,
+                }}
+              >
+                {child}
+              </ComponentCode>
+            ))
+          )}
+        </ExpanderContent>
+      </Expander>
     </>
   );
 };

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -31,7 +31,7 @@ const Footer: React.FunctionComponent = () => {
               <Text>{t('footer.left_text')}</Text>
             </Block>
             <Block className={styles.links}>
-              <Link href="/info" passHref>
+              <Link href="/privacy-statement" passHref>
                 <RouterLink>{t('footer.cookies')}</RouterLink>
               </Link>
               <Link href="/accessibility-statement" passHref>

--- a/components/Header/Navbar/Navbar.module.scss
+++ b/components/Header/Navbar/Navbar.module.scss
@@ -17,7 +17,7 @@
       min-height: 43px;
 
       &:hover {
-        border-bottom: 4px solid $fi-color-brand-base;
+        border-bottom: 4px solid $fi-color-highlight-base;
       }
 
       a {
@@ -31,5 +31,5 @@
 }
 
 .active {
-  border-bottom: 4px solid $fi-color-brand-base;
+  border-bottom: 4px solid $fi-color-highlight-base;
 }

--- a/components/Header/Navbar/Navbar.module.scss
+++ b/components/Header/Navbar/Navbar.module.scss
@@ -25,6 +25,15 @@
         padding: $fi-spacing-inset-m;
         color: $fi-color-black-base;
         text-decoration: none;
+
+        &:focus-visible {
+          outline: 0;
+          position: relative;
+      
+          &:after {
+            @include fi-focus-absolute-focus;
+          }
+        }
       }
     }
   }

--- a/components/SpacingShowcase/SpacingShowcase.tsx
+++ b/components/SpacingShowcase/SpacingShowcase.tsx
@@ -2,6 +2,10 @@ import { suomifiDesignTokens, ValueUnit } from 'suomifi-design-tokens';
 import styled from 'styled-components';
 import { Text } from 'suomifi-ui-components';
 
+interface SpacingShowcaseProps {
+  values: 'normal' | 'inset';
+}
+
 /**
  * Return CSS compatible string
  * @param cssValue number, string or {value: number, unit: string | null}
@@ -99,11 +103,15 @@ const Name = styled(({ name, value, ...passProps }) => (
 `,
 );
 
-const SpacingShowcase: React.FunctionComponent = () => {
+const SpacingShowcase: React.FunctionComponent<SpacingShowcaseProps> = ({
+  values,
+}) => {
   return (
     <>
       {Object.entries(suomifiDesignTokens.spacing).map(([key, value]) => {
         const spacingValue = cssValueToString(value);
+        if (values === 'inset' && !key.startsWith('inset')) return;
+        if (values !== 'inset' && key.startsWith('inset')) return;
         return (
           <Container size={spacingValue} key={key}>
             <Name name={key} value={spacingValue} />

--- a/i18n/translations.fi.json
+++ b/i18n/translations.fi.json
@@ -141,7 +141,7 @@
      "heading": "Välistys",
      "ingress": "Suomi.fi Design System sisältää valmiiksi määriteltyjä arvoja tilankäytölle. Näitä välistystokeneita käyttämällä verkkosivun asettelu pysyy yhtenäisenä ja harmonisena.",
      "paragraph_1": "Seuraavia välistyksiä käytetään sivulla olevien elementtien välisen tilan luomiseen.",
-     "paragraph_2": "Design Systemiin kuuluvaa lohkokomponenttia voidaan käyttää tilan luomiseen hyödyntämällä sen marginaali- ja täyteominaisuuksia.",
+     "paragraph_2": "Design Systemiin kuuluvaa lohkokomponenttia voidaan käyttää tilan luomiseen hyödyntämällä sen marginaali- ja täyteominaisuuksia (padding).",
      "block_text_1": "Lohko, jossa on eri määrä tilaa eri reunoilla",
      "block_text_2": "Lohko, jolla on yläpuolen marginaalia",
      "inset_heading": "Inset-välistykset",

--- a/i18n/translations.fi.json
+++ b/i18n/translations.fi.json
@@ -142,7 +142,7 @@
      "ingress": "Suomi.fi Design System sisältää valmiiksi määriteltyjä arvoja tilankäytölle. Näitä välistystokeneita käyttämällä verkkosivun asettelu pysyy yhtenäisenä ja harmonisena.",
      "paragraph_1": "Seuraavia välistyksiä käytetään sivulla olevien elementtien välisen tilan luomiseen.",
      "paragraph_2": "Design Systemiin kuuluvaa lohkokomponenttia voidaan käyttää tilan luomiseen hyödyntämällä sen marginaali- ja täyteominaisuuksia (padding).",
-     "block_text_1": "Lohko, jossa on eri määrä tilaa eri reunoilla",
+     "block_text_1": "Lohko, jossa on eri määrä tilaa (padding) eri reunoilla",
      "block_text_2": "Lohko, jolla on yläpuolen marginaalia",
      "inset_heading": "Inset-välistykset",
      "paragraph_3": "Inset-tokeneita käytetään komponenttien tai elementtien sisäisen välistyksen luomiseen."

--- a/i18n/translations.fi.json
+++ b/i18n/translations.fi.json
@@ -83,7 +83,7 @@
  },
  "colors": {
      "heading": "Värit",
-     "ingress": "Pääväreihin kuuluvat sininen (brandBase ja highlightBase), valkoinen (whiteBase) ja harmaa (depthBase). Tekstien päävärinä käytetään mustaa (blackBase). Korosteväreinä käytetään oranssia (accentBase) ja harmaan eri sävyjä. Yleisilme on vaalean neutraali, ja väriä käytetään harkiten korostamaan keskeisiä toimintoja ja sisältöjä.",
+     "ingress": "Suomi.fi-väriteeman pääväreihin kuuluu sininen (brandBase ja highlightBase), valkoinen (whiteBase) ja harmaa (depthBase). Tekstien päävärinä käytetään mustaa (blackBase). Korosteväreinä käytetään oranssia (accentBase) ja harmaan eri sävyjä. Yleisilme on vaalean neutraali, ja väriä käytetään harkiten korostamaan keskeisiä toimintoja ja sisältöjä.",
      "accessibility_list": {
          "point_1": "Kun käytät komponenttien tarjoamaa valmista Suomi.fi-väriteemaa käyttöohjeistuksien mukaisesti, täyttyvät saavutettavuuskriteeristön (WCAG) kontrastivaatimukset ja väriyhdistelmät ovat saavutettavuudeltaan riittäviä.",
          "point_2": "Jos haluat modifioida värit sopimaan erilaiseen visuaaliseen ilmeeseen, muista varmistaa, että valitsemasi väriyhdistelmien kontrastit täyttävät saavutettavuuskriteeristön (WCAG) asettamat vaatimukset.",

--- a/i18n/translations.fi.json
+++ b/i18n/translations.fi.json
@@ -26,7 +26,7 @@
     "home": "Etusivu",
     "styles": "Tyylit",
     "components": "Komponentit",
-    "info": "Taustatietoa"
+    "info": "Yleistä Design Systemistä"
   },
   "footer": {
     "left_text": "Suomi.fi Design Systemin kehittämisestä vastaa Digi- ja väestötietovirasto.",
@@ -43,82 +43,151 @@
     "paragraph_1": "Tässä saavutettavuusselosteessa kerrotaan, miten Suomi.fi Design System -sivustolla noudatetaan lakia digitaalisten palvelujen tarjoamisesta, mitä puutteita sivuston saavutettavuudessa on ja miten voit antaa meille palautetta saavutettavuusongelmista. Seloste on laadittu 19.9.2019.",
     "paragraph_2": "Tästä verkkopalvelusta vastaa Digi- ja väestötietovirasto. Haluamme, että mahdollisimman moni käyttäjä pystyy käyttämään digitaalisia palvelujamme. Otamme saavutettavuuden huomioon digitaalisten palvelujen kehityksessä. Palvelujen saavutettavuutta arvioidaan säännöllisesti osana suunnittelu- ja kehitystyötä.",
     "how_accessible_are_pages": {
-      "heading": "Miten saavutettavia sivut ovat?",
-      "paragraph": "Tämä sivusto täyttää lain vaatimat A- ja AA-tason saavutettavuuskriteerit (WCAG-kriteeristö 2.1)."
+        "heading": "Miten saavutettavia sivut ovat?",
+        "paragraph": "Tämä sivusto täyttää lain vaatimat A- ja AA-tason saavutettavuuskriteerit (WCAG-kriteeristö 2.1)."
     },
     "notice_problems": {
-      "heading": "Huomasitko puutteita saavutettavuudessa?",
-      "paragraph": "Pyrimme jatkuvasti huolehtimaan saavutettavuudesta. Jos löydät ongelmia, ilmoita niistä meille ja teemme parhaamme puutteiden korjaamiseksi. Vastaamme mahdollisimman pian tai viimeistään kahden viikon sisällä. Voit ottaa yhteyttä sähköpostitse osoitteella saavutettavuus(at)dvv.fi."
+        "heading": "Huomasitko puutteita saavutettavuudessa?",
+        "paragraph": "Pyrimme jatkuvasti huolehtimaan saavutettavuudesta. Jos löydät ongelmia, ilmoita niistä meille ja teemme parhaamme puutteiden korjaamiseksi. Vastaamme mahdollisimman pian tai viimeistään kahden viikon sisällä. Voit ottaa yhteyttä sähköpostitse osoitteella saavutettavuus(at)dvv.fi."
     },
     "supervision": {
-      "heading": "Saavutettavuuden valvonta",
-      "paragraph": "Etelä-Suomen aluehallintovirasto valvoo saavutettavuusvaatimusten toteutumista. Jos et ole tyytyväinen saamaasi vastaukseen tai et saa vastausta lainkaan kahden viikon aikana, voit antaa palautteen Etelä-Suomen aluehallintovirastoon. Etelä-Suomen aluehallintoviraston sivulla kerrotaan tarkasti, miten valituksen voi tehdä ja miten asia käsitellään."
+        "heading": "Saavutettavuuden valvonta",
+        "paragraph": "Etelä-Suomen aluehallintovirasto valvoo saavutettavuusvaatimusten toteutumista. Jos et ole tyytyväinen saamaasi vastaukseen tai et saa vastausta lainkaan kahden viikon aikana, voit antaa palautteen Etelä-Suomen aluehallintovirastoon. Etelä-Suomen aluehallintoviraston sivulla kerrotaan tarkasti, miten valituksen voi tehdä ja miten asia käsitellään."
     },
     "contacts": {
-      "heading": "Valvontaviranomaisen yhteystiedot",
-      "paragraph_1": "Etelä-Suomen aluehallintovirasto",
-      "paragraph_2": "Saavutettavuuden valvonnan yksikkö",
-      "paragraph_3": "www.saavutettavuusvaatimukset.fi",
-      "paragraph_4": "sähköposti: saavutettavuus(at)avi.fi",
-      "paragraph_5": "puhelin: vaihde 0295 016 000"
+        "heading": "Valvontaviranomaisen yhteystiedot",
+        "paragraph_1": "Etelä-Suomen aluehallintovirasto",
+        "paragraph_2": "Saavutettavuuden valvonnan yksikkö",
+        "paragraph_3": "www.saavutettavuusvaatimukset.fi",
+        "paragraph_4": "sähköposti: saavutettavuus(at)avi.fi",
+        "paragraph_5": "puhelin: vaihde 0295 016 000"
     },
     "testing": {
-      "heading": "Miten olemme testanneet saavutettavuutta?",
-      "paragraph": "Saavutettavuus on huomioitu Digi- ja väestötietoviraston digitaalisten palvelujen kehityksessä suunnittelusta toteutukseen kokonaisketterän mallin mukaisesti. Verkkosivuston saavutettavuutta on arvioinut Digi- ja väestötietoviraston hankkima saavutettavuusasiantuntija säännöllisesti osana suunnittelu- ja kehitysprosessia."
+        "heading": "Miten olemme testanneet saavutettavuutta?",
+        "paragraph": "Saavutettavuus on huomioitu Digi- ja väestötietoviraston digitaalisten palvelujen kehityksessä suunnittelusta toteutukseen kokonaisketterän mallin mukaisesti. Verkkosivuston saavutettavuutta on arvioinut Digi- ja väestötietoviraston hankkima saavutettavuusasiantuntija säännöllisesti osana suunnittelu- ja kehitysprosessia."
     }
   },
-  "styles": {
-    "styles_usage_info": "Tyylien käyttöohje",
-    "colors": "Värit",
-    "icons": "Ikonit",
-    "spacing": "Välistys"
-  },
-  "styles_main_page": {
-    "ingress": "Design system tarjoaa Suomi.fi-identiteetin mukaisia, valmiiksi paketoituja tyylimäärittelyjä eli tokeneita. Design systemiin kuuluvan komponenttikirjaston tyylit pohjautuvat näihin tokeneihin.",
-    "paragraph_1": "Suomi.fi design tokenit löytyvät erillisenä pakettina yhdestä npm-moduulista. Tokeneiden tekninen ja käyttöönottoohjeistus löytyy GitHub-dokumentaatiosta.",
-    "style_usage": "Tyylien käyttö",
-    "style_usage_paragraph_1": "Tokeneita hyödyntämällä voi oman sivustonsa tyylit pitää linjassa Suomi.fi-teeman kanssa. Tokeneita voi käyttää suoraa omasta npm-moduulistaan.",
-    "style_usage_paragraph_2": "Vaihtoehtoisesti tokenit ovat käytettävissä myös komponenttikirjaston teemaobjektin kautta alla olevan esimerkin mukaisesti.",
-    "styled_element": "Tyylitelty elementti"
-  },
-  "colors": {
-    "heading": "Värit",
-    "ingress": "Pääväreihin kuuluvat sininen (brandBase) sekä (highlightBase), valkoinen (whiteBase) ja harmaa (depthBase). Tekstien päävärinä käytetään mustaa (blackBase). Korosteväreinä käytetään oranssia (accentBase) ja harmaan eri sävyjä. Yleisilme on vaalean neutraali, ja väriä käytetään harkiten korostamaan keskeisiä toimintoja ja sisältöjä.",
-    "accessibility_list": {
-      "point_1": "Kun käytät komponenttien tarjoamaa valmista Suomi.fi-väriteemaa käyttöohjeistuksien mukaisesti, täyttyvät saavutettavuuskriteeristön (WCAG) kontrastivaatimukset ja väriyhdistelmät ovat saavutettavuudeltaan riittäviä.",
-      "point_2": "Jos haluat modifioida värit sopimaan erilaiseen visuaaliseen ilmeeseen, muista varmistaa, että valitsemasi väriyhdistelmien kontrastit täyttävät saavutettavuuskriteeristön (WCAG) asettamat vaatimukset.",
-      "point_3": "Huomioi, että saavutettavuuskriteeristön (WCAG) kontrastivaatimukset eivät koske komponentteja, joiden käyttö on estetty. On kuitenkin tärkeää varmistaa, että estetty sävy eroaa kontrastiltaan tarpeeksi aktiivisen tilan väristä. Suomi.fi-komponentteihin on toteutettu valmiiksi estetty-tila oikeaoppisesti.",
-      "point_4": "Tutustu näihin kohtiin tarkemmin saavutettavuuskriteeristön ohjeistuksessa: WCAG 2.1., onnistumiskriteeri 1.4.3 Kontrasti (minimi)."
-    },
-    "contrast_link": "WCAG 2.1 kontrastivaatimukset",
-    "texts": {
-      "heading": "Tekstit",
-      "paragraph": "Tekstien pääväri on musta (blackBase). Mustaa käytetään myös joidenkin komponenttien yhteydessä olevissa vihjeteksteissä. Estetyissä (disabled) teksteissä käytetään vaalean harmaata (depthBase). Paikanvaraajanteksteissä käytetään tummanharmaata (depthDark2)."
-    },
-    "brand": {
-      "heading": "Brändi",
-      "paragraph": "Brändiväriä (brandBase) käytetään Suomi.fi-palveluiden logossa, alatunnisteessa sekä palveluiden yläreunan värillisessä palkissa."
-    }
-  },
-  "icons": {
-    "heading": "Ikonit",
-    "ingress": "Tältä sivulla löydät kaikki ikonit jotka ovat käytössä suomi.fi palveluissa. Ikonien käyttöohjeistukset löydät ikonikomponentin sivulta.",
-    "base_icons": {
-      "title": "Perusikonit (base icons)",
-      "link_title": "Perusikonit GitHubissa SVG-muodossa"
-    },
-    "illustrative_icons": {
-      "title": "Kuvitusikonit (illustrative icons)",
-      "link_title": "Kuvitusikonit GitHubissa SVG-muodossa"
-    },
-    "doctype_icons": {
-      "title": "Liitetiedostoikonit (doctype icons)",
-      "link_title": "Liitetiedostoikonit GitHubissa SVG-muodossa"
-    }
-  },
-  "spacing": {
-    "heading": "Välistys",
-    "ingress": "Lorem ipsum asdasd"
+ "styles": {
+     "styles_usage_info": "Tyylien käyttöohje",
+     "colors": "Värit",
+     "icons": "Ikonit",
+     "spacing": "Välistys"
+ },
+ "styles_main_page": {
+     "ingress": "Design System tarjoaa Suomi.fi-identiteetin mukaisia, valmiiksi paketoituja tyylimäärittelyjä eli tokeneita. Design Systemiin kuuluvan komponenttikirjaston tyylit pohjautuvat näihin tokeneihin.",
+     "paragraph_1": "Suomi.fi design tokenit löytyvät erillisenä pakettina yhdestä npm-moduulista. Niitä voi käyttää joko Javascript-muodossa (CSS-in-JS) tai SCSS-muodossa. Tokeneiden tarkempi käyttöohjeistus löytyy GitHub-dokumentaatiosta.",
+     "style_usage": "Tyylitokeneiden käyttö",
+     "style_usage_paragraph_1": "Tokeneita hyödyntämällä voi oman sivustonsa tyylit pitää linjassa Suomi.fi-teeman kanssa. Tokeneita voi käyttää suoraan omasta npm-moduulistaan kuten seuraavassa koodiesimerkissä.",
+     "style_usage_paragraph_2": "Vaihtoehtoisesti tokenit ovat käytettävissä myös komponenttikirjaston teemaobjektin kautta alla olevan esimerkin mukaisesti.",
+     "styled_element": "Tyylitelty elementti"
+ },
+ "colors": {
+     "heading": "Värit",
+     "ingress": "Pääväreihin kuuluvat sininen (brandBase ja highlightBase), valkoinen (whiteBase) ja harmaa (depthBase). Tekstien päävärinä käytetään mustaa (blackBase). Korosteväreinä käytetään oranssia (accentBase) ja harmaan eri sävyjä. Yleisilme on vaalean neutraali, ja väriä käytetään harkiten korostamaan keskeisiä toimintoja ja sisältöjä.",
+     "accessibility_list": {
+         "point_1": "Kun käytät komponenttien tarjoamaa valmista Suomi.fi-väriteemaa käyttöohjeistuksien mukaisesti, täyttyvät saavutettavuuskriteeristön (WCAG) kontrastivaatimukset ja väriyhdistelmät ovat saavutettavuudeltaan riittäviä.",
+         "point_2": "Jos haluat modifioida värit sopimaan erilaiseen visuaaliseen ilmeeseen, muista varmistaa, että valitsemasi väriyhdistelmien kontrastit täyttävät saavutettavuuskriteeristön (WCAG) asettamat vaatimukset.",
+         "point_3": "Huomioi, että saavutettavuuskriteeristön (WCAG) kontrastivaatimukset eivät koske komponentteja, joiden käyttö on estetty. On kuitenkin tärkeää varmistaa, että estetty sävy eroaa kontrastiltaan tarpeeksi aktiivisen tilan väristä. Suomi.fi-komponentteihin on toteutettu valmiiksi estetty-tila oikeaoppisesti.",
+         "point_4": "Tutustu näihin kohtiin tarkemmin saavutettavuuskriteeristön ohjeistuksessa: WCAG 2.1., onnistumiskriteeri 1.4.3 Kontrasti (minimi)."
+     },
+     "contrast_link": "WCAG 2.1 kontrastivaatimukset",
+     "brand": {
+         "heading": "Brändiväri",
+         "paragraph": "Brändiväriä (brandBase) käytetään Suomi.fi-palveluiden logossa, alatunnisteessa sekä palveluiden yläreunan värillisessä palkissa."
+     },
+     "texts": {
+         "heading": "Tekstit",
+         "paragraph": "Tekstien pääväri on musta (blackBase). Mustaa käytetään myös joidenkin komponenttien yhteydessä olevissa vihjeteksteissä. Estetyissä (disabled) teksteissä käytetään vaalean harmaata (depthBase). Paikanvaraajanteksteissä käytetään tummanharmaata (depthDark2)."
+     },
+     "functionals": {
+         "heading": "Linkit, painikkeet ja valinnat",
+         "paragraph": "Sinistä (highlightBase) sekä siitä johdettuja vaalempia sävyä (highlightLight) käytetään interaktiivisissa elementeissä ja valittujen elementtien korostamisessa. Violettia (accentTertiaryDark1) käytetään linkkien vierailun jälkeisessä tilassa (visited state). Estetyissä tiloissa käytetään harmaata (depthBase). Sinisestä johdettua tummempaa sävyä (highlightDark1) käytetään esimerkiksi painikkeiden hovertilassa (hover state). Sinistä korostusväriä (accentSecondary) käytetään kaikkien komponenttien fokustilassa (focus state).    "
+     },
+     "icons": {
+         "heading": "Ikonit",
+         "paragraph": "Kuvitusikoneissa käytetään harmaata (depthBase) sekä oranssia (accentBase) korostevärinä. Toiminnallisissa ikoneissa käytetään toiminnallisten elementtien sinistä (highlightBase) väriä sekä tummaa harmaata (depthDark1)."
+     },
+     "borders": {
+         "heading": "Taustat ja reunukset",
+         "paragraph": "Sivun taustaväri on vaalean harmaa (depthLight3) ja sisältöalueen tausta on valkea (whiteBase). Reunuksien väri on harmaa (depthLight1). Lisäksi käytössä on sinisestä (highlightBase) väristä johdettuja sävyjä (highlightLight4, highlightLight3 ja highlightLight2) sekä haalea vaaleansininen (depthSecondary)."
+     },
+     "trafficlights": {
+         "heading": "Liikennevalovärit",
+         "paragraph": "Liikennevalovärit kuvaavat komponenttien, elementtien tai toimintojen tilatietoa. Vihreä (successBase) kuvaa onnistumista tai positiivista toimintoa. Keltainen (warningBase) kuvaa esim. tehtävää tai muuta asiaa, johon käyttäjän tulee reagoida. Punainen (alertBase) kuvaa virhetilaa tai häiriötä. Pelkkä väri ei riitä tiedon tai toiminnallisuuksien esittämiseen vaan tieto pitää esittää myös sanallisesti."
+     },
+     "accents": {
+         "heading": "Korostevärit",
+         "paragraph": "Korostevärejä käytetään tilanteissa, joissa väriä tarvitaan luomaan eroavaisuutta muista elementeistä."
+     }
+ },
+ "icons": {
+     "heading": "Ikonit",
+     "ingress": "Tältä sivulla löydät kaikki Suomi.fi Design Systemin sisältämät ikonit. Ikonien käyttöohjeistukset löydät ikonikomponentin sivulta.",
+     "icon_component_link_text": "Ikonikomponentti",
+     "base_icons": {
+         "title": "Perusikonit (base icons)",
+         "link_title": "Perusikonit GitHubissa SVG-muodossa"
+     },
+     "illustrative_icons": {
+         "title": "Kuvitusikonit (illustrative icons)",
+         "link_title": "Kuvitusikonit GitHubissa SVG-muodossa"
+     },
+     "doctype_icons": {
+         "title": "Liitetiedostoikonit (doctype icons)",
+         "link_title": "Liitetiedostoikonit GitHubissa SVG-muodossa"
+     }
+ },
+ "spacing": {
+     "heading": "Välistys",
+     "ingress": "Suomi.fi Design System sisältää valmiiksi määriteltyjä arvoja tilankäytölle. Näitä välistystokeneita käyttämällä verkkosivun asettelu pysyy yhtenäisenä ja harmonisena.",
+     "paragraph_1": "Seuraavia välistyksiä käytetään sivulla olevien elementtien välisen tilan luomiseen.",
+     "paragraph_2": "Design Systemiin kuuluvaa lohkokomponenttia voidaan käyttää tilan luomiseen hyödyntämällä sen marginaali- ja täyteominaisuuksia.",
+     "block_text_1": "Lohko, jossa on eri määrä tilaa eri reunoilla",
+     "block_text_2": "Lohko, jolla on yläpuolen marginaalia",
+     "inset_heading": "Inset-välistykset",
+     "paragraph_3": "Inset-tokeneita käytetään komponenttien tai elementtien sisäisen välistyksen luomiseen."
+ },
+ "info": {
+     "info": "Yleistä Design Systemistä",
+     "accessibility": "Saavutettavuus"
+ },
+ "info_main_page": {
+     "ingress": "Suomi.fi Design System tarjoaa kokoelman saavutettavia, uudelleenkäytettäviä ja dokumentoituja käyttöliittymäkomponentteja sekä ohjeistuksen niiden käyttöön. Design System -kirjaston komponentit ovat yhteismitallisia rakennuspalikoita, jotka auttavat niin suunnittelijoita kuin kehittäjiäkin toteuttamaan yhdenmukaisia palveluja. Voit hyödyntää komponentteja joko sellaisenaan tai muokata niiden ulkoasua vastaamaan oman palvelusi visuaalista ilmettä.",
+     "ux_and_accessibility": {
+         "heading": "Käyttäjäkokemus ja saavutettavuus",
+         "paragraph_1": "Yhdenmukaisten käyttöliittymäkomponenttien avulla eri palvelut näyttäytyvät käyttäjille yhtenäisinä ja käyttäjäkokemus säilyy eheänä. Käyttämällä samanlaisia elementtejä johdonmukaisesti, tuotamme palvelun käyttäjälle intuitiivisen ja ymmärrettävän käyttökokemuksen. Yhdenmukaisesti toimivat palvelut ovat käyttäjien etu.",
+         "paragraph_2": "Saavutettavuudesta huolehtiminen on erittäin keskeinen osa Suomi.fi Design System -kirjastoa. Kaikissa ratkaisuissa huomioidaan jo suunnitteluvaiheessa saavutettavuuskriteerit (WCAG 2.1). Apuvälinekäytön lisäksi suunnittelussa huomioidaan myös kognitiivinen saavutettavuus. Kaikki komponentit myös testataan saavutettavuusvaatimusten mukaisesti ennen niiden julkaisua."
+     },
+     "brand": {
+         "heading": "Suomi.fi-brändi",
+         "paragraph_1": "Kaikki Suomi.fi-kokonaisuuteen kuuluvat eri palvelut käyttävät Suomi.fi-brändiä, jota hallinnoi Digi- ja väestötietovirasto. Suomi.fi Design System -kirjaston käyttöliittymäkomponentit pohjautuvat Suomi.fi-brändin visuaaliseen ilmeeseen.",
+         "paragraph_2": "Suomi.fi-brändiperheeseen kuuluu useita sähköisen asioinnin tukipalveluja. Näitä ovat esimerkiksi: Suomi.fi-verkkopalvelu, Palvelutietovaranto, Tunnistus, Viestit, Valtuudet, Kartat, Maksut, Palveluhallinta ja palveluväylän Liityntäkatalogi. Suomi.fi-logon käyttäminen palvelun tunnuksena on sallittua ainoastaan Suomi.fi-brändiperheeseen kuuluvissa palveluissa.",
+         "paragraph_3": "Digi- ja väestötietoviraston uudet digitaaliset asiointipalvelut kansalaisille toteutetaan myös yhtenäisen Suomi.fi-käyttökokemuksen mukaisesti."
+     },
+     "ask_and_comment": {
+         "heading": "Kysy ja kommentoi",
+         "paragraph_1": "Kehittäjien ja komponenttikirjaston käyttäjien välinen keskustelu löytyy GitHubista.",
+         "link_text": "GitHub"
+     }
+ },
+ "accessibility_page": {
+     "ingress": "Saavutettavuudella tarkoitetaan, että digitaaliset palvelut, verkkosivustot ja mobiilisovellukset sekä niiden sisällöt ovat sellaisia, että kuka tahansa voisi niitä käyttää ja ymmärtää, mitä niissä sanotaan. Verkkopalvelujen saavutettavuus koskee EU:n saavutettavuusdirektiivin ja sitä toteuttavan lain (Laki digitaalisten palvelujen tarjoamisesta) myötä koko julkista sektoria sekä osaa järjestöistä ja yrityksistä.",
+     "paragraph_1": "Suomi.fi Design System -kirjaston avulla Digi- ja väestötietovirasto haluaa tukea ja edistää saavutettavien verkkopalvelujen rakentamista. Design Systemin -kirjastoon toteutettujen käyttöliittymäkomponenttien saavutettavuus varmistetaan sekä suunnittelu- että toteutusvaiheessa saavutettavuusasiantuntijan kanssa. Kaikki komponentit myös testataan ennen niiden julkaisua.",
+     "paragraph_2": "Laki digitaalisten palvelujen tarjoamisesta astui voimaan 1.4.2019. Saavutettavuusvaatimusten pohjana toimii World Wide Web Consortiumin laatima verkkosisältöjen saavutettavuusohjeistus WCAG 2.1 (tasot A ja AA).",
+     "link_1": "Laki digitaalisten palvelujen tarjoamisesta",
+     "link_2": "EU:n saavutettavuusdirektiivi",
+     "link_3": "WCAG 2.1 -ohjeistus",
+     "multiple_factors": {
+         "heading": "Saavutettavuus koostuu useista tekijöistä",
+         "paragraph_1": "Saavutettavuusdirektiivi ja lainsäädäntö sisältävät ennen kaikkea määräyksiä teknisistä vaatimuksista, joilla parannetaan saavutettavuutta. Yhtä tärkeitä osatekijöitä hyvän saavutettavuuden toteuttamiseksi ovat visuaalisen ilmeen saavutettavuus, rakenteen saavutettavuus sekä sisältöjen ymmärrettävyys ja selkeys.",
+         "paragraph_2": "Vaikka käyttöliittymäkomponentit itsessään olisivat saavutettavia, se ei kuitenkaan takaa, että palvelu kokonaisuudessaan on saavutettava. Suomi.fi Design Systemin komponenttikohtainen käyttöohjeistus auttaa käyttämään komponentteja oikein. On kuitenkin muistettava, että verkkopalvelun lopullinen kokonaisvaltainen saavutettavuus vaatii aina erillistä työtä, harkintaa ja testausta.",
+         "paragraph_3": "Teknisen saavutettavuuden lisäksi tulee muistaa sisältöjen saavutettavuus (kognitiivinen saavutettavuus). Kognitiivinen saavutettavuus käsittää yhteisesti palvelussa esitettävän tiedon ja tavat, miten tieto esitetään käyttäjälle ymmärrettävästi. Sisältöjen ymmärrettävyys ja selkeys helpottavat jokaisen asiointia palvelussa. Koska kognitiivisia ominaisuuksia on vaikeampi mitata kuin teknisiä ominaisuuksia, on mahdollista, että digitaalinen palvelu ei ole helppokäyttöinen, vaikka palvelu täyttäisikin saavutettavuusvaatimukset.",
+         "point_1": "Ymmärrettävyys tarkoittaa sitä, että palvelun sisällöt ja toiminta on esitetty käyttäjän ymmärtämällä tavalla. Käyttäjä siis käsittää, mitä hän on palvelussa tekemässä.",
+         "point_2": "Palvelun sisältöjen osalta ymmärrettävyys tarkoittaa kielelliseen ilmaisuun liittyviä keinoja, joilla palvelun sisältö on käyttäjälle yksiselitteistä. Ymmärrettävyys tarkoittaa myös käyttöliittymässä käytettävien tekstien, erilaisten toimintojen ja palvelun logiikan kokonaisuutta. Tekstimuotoisen sisällön osalta ymmärrettävyys tarkoittaa lähtökohtaisesti selkeän ja hyvän yleiskielen käyttämistä.",
+         "point_3": "Visuaalinen saavutettavuus tarkoittaa sitä, että palvelun käyttökokemus on johdonmukainen, käyttöliittymä on selkeä ja visuaalinen hierarkia tukee palvelun käytettävyyttä.",
+         "point_4": "Digitaalisen palvelun toiminnan ja logiikan osalta ymmärrettävyys tarkoittaa erilaisia varmistuskeinoja, joilla käyttäjälle kerrotaan missä vaiheessa palvelua hän on ja miten hän pääsee liikkumaan palvelussa. Käyttäjälle myös kerrotaan eri toimintojen vaikutuksista ja hän ymmärtää eri toimintojen seuraukset ja yhtymäkohdat.",
+         "link": "Lue lisää saavutettavuusvaatimuksista aluehallintoviraston sivuilta"
+     }
   },
   "components": {
     "component_usage_info": "Komponenttien käyttöohje",

--- a/i18n/translations.fi.json
+++ b/i18n/translations.fi.json
@@ -87,7 +87,7 @@
      "accessibility_list": {
          "point_1": "Kun käytät komponenttien tarjoamaa valmista Suomi.fi-väriteemaa käyttöohjeistuksien mukaisesti, täyttyvät saavutettavuuskriteeristön (WCAG) kontrastivaatimukset ja väriyhdistelmät ovat saavutettavuudeltaan riittäviä.",
          "point_2": "Jos haluat muokata värejä sopimaan erilaiseen visuaaliseen ilmeeseen, muista varmistaa, että valitsemasi väriyhdistelmien kontrastit täyttävät saavutettavuuskriteeristön (WCAG) asettamat vaatimukset.",
-         "point_3": "Huomioi, että saavutettavuuskriteeristön (WCAG) kontrastivaatimukset eivät koske komponentteja, joiden käyttö on estetty. On kuitenkin tärkeää varmistaa, että estetty sävy eroaa kontrastiltaan tarpeeksi aktiivisen tilan väristä. Suomi.fi-komponentteihin on toteutettu valmiiksi estetty-tila oikeaoppisesti.",
+         "point_3": "Huomioi, että saavutettavuuskriteeristön (WCAG) kontrastivaatimukset eivät koske komponentteja, joiden käyttö on estetty. On kuitenkin tärkeää varmistaa, että estetty sävy eroaa kontrastiltaan tarpeeksi aktiivisen tilan väristä.",
          "point_4": "Tutustu näihin kohtiin tarkemmin saavutettavuuskriteeristön ohjeistuksessa: WCAG 2.1., onnistumiskriteeri 1.4.3 Kontrasti (minimi)."
      },
      "contrast_link": "WCAG 2.1 kontrastivaatimukset",

--- a/i18n/translations.fi.json
+++ b/i18n/translations.fi.json
@@ -74,7 +74,7 @@
      "spacing": "Välistys"
  },
  "styles_main_page": {
-     "ingress": "Design System tarjoaa Suomi.fi-identiteetin mukaisia, valmiiksi paketoituja tyylimäärittelyjä eli tokeneita. Design Systemiin kuuluvan komponenttikirjaston tyylit pohjautuvat näihin tokeneihin.",
+     "ingress": "Design System tarjoaa Suomi.fi-identiteetin mukaisia tyylimäärittelyjä eli tokeneita. Design Systemiin kuuluvan komponenttikirjaston tyylit pohjautuvat näihin tokeneihin.",
      "paragraph_1": "Suomi.fi design tokenit löytyvät erillisenä pakettina yhdestä npm-moduulista. Niitä voi käyttää joko Javascript-muodossa (CSS-in-JS) tai SCSS-muodossa. Tokeneiden tarkempi käyttöohjeistus löytyy GitHub-dokumentaatiosta.",
      "style_usage": "Tyylitokeneiden käyttö",
      "style_usage_paragraph_1": "Tokeneita hyödyntämällä voi oman sivustonsa tyylit pitää linjassa Suomi.fi-teeman kanssa. Tokeneita voi käyttää suoraan omasta npm-moduulistaan kuten seuraavassa koodiesimerkissä.",

--- a/i18n/translations.fi.json
+++ b/i18n/translations.fi.json
@@ -86,7 +86,7 @@
      "ingress": "Suomi.fi-väriteeman pääväreihin kuuluu sininen (brandBase ja highlightBase), valkoinen (whiteBase) ja harmaa (depthBase). Tekstien päävärinä käytetään mustaa (blackBase). Korosteväreinä käytetään oranssia (accentBase) ja harmaan eri sävyjä. Yleisilme on vaalean neutraali, ja väriä käytetään harkiten korostamaan keskeisiä toimintoja ja sisältöjä.",
      "accessibility_list": {
          "point_1": "Kun käytät komponenttien tarjoamaa valmista Suomi.fi-väriteemaa käyttöohjeistuksien mukaisesti, täyttyvät saavutettavuuskriteeristön (WCAG) kontrastivaatimukset ja väriyhdistelmät ovat saavutettavuudeltaan riittäviä.",
-         "point_2": "Jos haluat modifioida värit sopimaan erilaiseen visuaaliseen ilmeeseen, muista varmistaa, että valitsemasi väriyhdistelmien kontrastit täyttävät saavutettavuuskriteeristön (WCAG) asettamat vaatimukset.",
+         "point_2": "Jos haluat muokata värejä sopimaan erilaiseen visuaaliseen ilmeeseen, muista varmistaa, että valitsemasi väriyhdistelmien kontrastit täyttävät saavutettavuuskriteeristön (WCAG) asettamat vaatimukset.",
          "point_3": "Huomioi, että saavutettavuuskriteeristön (WCAG) kontrastivaatimukset eivät koske komponentteja, joiden käyttö on estetty. On kuitenkin tärkeää varmistaa, että estetty sävy eroaa kontrastiltaan tarpeeksi aktiivisen tilan väristä. Suomi.fi-komponentteihin on toteutettu valmiiksi estetty-tila oikeaoppisesti.",
          "point_4": "Tutustu näihin kohtiin tarkemmin saavutettavuuskriteeristön ohjeistuksessa: WCAG 2.1., onnistumiskriteeri 1.4.3 Kontrasti (minimi)."
      },

--- a/layouts/SideNavLayout/SideNavLayout.module.scss
+++ b/layouts/SideNavLayout/SideNavLayout.module.scss
@@ -20,7 +20,7 @@
         @include upto-lg {
             display: none;
         }
-        width: 350px;
+        min-width: 370px;
 
         .navHeader {
             display: flex;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -5,6 +5,10 @@ class MyDocument extends Document {
     return (
       <Html lang="fi">
         <Head>
+          <link
+            href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600&display=swap"
+            rel="stylesheet"
+          />
           <link rel="shortcut icon" href="/favicon.svg" />
         </Head>
         <body>

--- a/pages/components/pagination.tsx
+++ b/pages/components/pagination.tsx
@@ -282,37 +282,35 @@ const FailingExample = ({
   return (
     <ComponentExample
       style={{
-        marginBottom: defaultSuomifiTheme.spacing.s,
         display: 'flex',
-        flexDirection: 'column',
+        justifyContent: 'center',
       }}
+      variant="mobile_device"
     >
-      <div style={{ width: '600px' }}>
-        <Pagination
-          currentPage={current}
-          lastPage={lastPage}
-          smallScreen={true}
-          nextButtonAriaLabel="Seuraava sivu"
-          previousButtonAriaLabel="Edellinen sivu"
-          pageInput={true}
-          aria-label="Esimerkki D"
-          pageInputProps={{
-            invalidValueErrorText: (value) => `"${value}" ei ole sallittu arvo`,
-            inputPlaceholderText: 'Siirry sivulle',
-            buttonText: 'Siirry sivulle',
-            labelText: 'Sivun numero',
-          }}
-          onChange={(page) => {
-            setCurrent(page);
-          }}
-          pageIndicatorText={(currentPage, lastPage) => {
-            return 'Sivu ' + currentPage + ' / ' + lastPage;
-          }}
-          ariaPageIndicatorText={(currentPage, lastPage) => {
-            return 'Näytetään sivu ' + currentPage + ' kautta ' + lastPage;
-          }}
-        />
-      </div>
+      <Pagination
+        currentPage={current}
+        lastPage={lastPage}
+        smallScreen={true}
+        nextButtonAriaLabel="Seuraava sivu"
+        previousButtonAriaLabel="Edellinen sivu"
+        pageInput={true}
+        aria-label="Esimerkki D"
+        pageInputProps={{
+          invalidValueErrorText: (value) => `"${value}" ei ole sallittu arvo`,
+          inputPlaceholderText: 'Siirry sivulle',
+          buttonText: 'Siirry sivulle',
+          labelText: 'Sivun numero',
+        }}
+        onChange={(page) => {
+          setCurrent(page);
+        }}
+        pageIndicatorText={(currentPage, lastPage) => {
+          return 'Sivu ' + currentPage + ' / ' + lastPage;
+        }}
+        ariaPageIndicatorText={(currentPage, lastPage) => {
+          return 'Näytetään sivu ' + currentPage + ' kautta ' + lastPage;
+        }}
+      />
     </ComponentExample>
   );
 };

--- a/pages/components/servicenavigation.tsx
+++ b/pages/components/servicenavigation.tsx
@@ -142,51 +142,49 @@ const Page: NextPage = () => {
             {t('service_navigation_page.example.smallscreen.paragraph')}
           </Paragraph>
 
-          <ComponentExample style={{ justifyContent: 'flex-start' }}>
-            <div style={{ width: '300px' }}>
-              <ServiceNavigation
-                aria-label={t('service_navigation_page.example.arialabel')}
-                variant="smallScreen"
-                smallScreenExpandButtonText={t(
-                  'service_navigation_page.example.smallscreen.buttontext',
-                )}
-                initiallyExpanded={false}
-              >
-                <ServiceNavigationItem>
-                  <RouterLink
-                    href="#"
-                    aria-label={t(
-                      'service_navigation_page.example.navitem1.arialabel',
-                    )}
-                  >
-                    {t('service_navigation_page.example.navitem1')}
-                    <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
-                      16
-                    </StaticChip>
-                  </RouterLink>
-                </ServiceNavigationItem>
-                <ServiceNavigationItem>
-                  <RouterLink href="#">
-                    {t('service_navigation_page.example.navitem2')}
-                  </RouterLink>
-                </ServiceNavigationItem>
-                <ServiceNavigationItem selected>
-                  <RouterLink href="#" aria-current="page">
-                    {t('service_navigation_page.example.navitem3')}
-                  </RouterLink>
-                </ServiceNavigationItem>
-                <ServiceNavigationItem>
-                  <RouterLink href="#">
-                    {t('service_navigation_page.example.navitem4')}
-                  </RouterLink>
-                </ServiceNavigationItem>
-                <ServiceNavigationItem>
-                  <RouterLink href="#">
-                    {t('service_navigation_page.example.navitem5')}
-                  </RouterLink>
-                </ServiceNavigationItem>
-              </ServiceNavigation>
-            </div>
+          <ComponentExample variant="mobile_device">
+            <ServiceNavigation
+              aria-label={t('service_navigation_page.example.arialabel')}
+              variant="smallScreen"
+              smallScreenExpandButtonText={t(
+                'service_navigation_page.example.smallscreen.buttontext',
+              )}
+              initiallyExpanded={false}
+            >
+              <ServiceNavigationItem>
+                <RouterLink
+                  href="#"
+                  aria-label={t(
+                    'service_navigation_page.example.navitem1.arialabel',
+                  )}
+                >
+                  {t('service_navigation_page.example.navitem1')}
+                  <StaticChip style={{ marginLeft: '15px' }} aria-hidden>
+                    16
+                  </StaticChip>
+                </RouterLink>
+              </ServiceNavigationItem>
+              <ServiceNavigationItem>
+                <RouterLink href="#">
+                  {t('service_navigation_page.example.navitem2')}
+                </RouterLink>
+              </ServiceNavigationItem>
+              <ServiceNavigationItem selected>
+                <RouterLink href="#" aria-current="page">
+                  {t('service_navigation_page.example.navitem3')}
+                </RouterLink>
+              </ServiceNavigationItem>
+              <ServiceNavigationItem>
+                <RouterLink href="#">
+                  {t('service_navigation_page.example.navitem4')}
+                </RouterLink>
+              </ServiceNavigationItem>
+              <ServiceNavigationItem>
+                <RouterLink href="#">
+                  {t('service_navigation_page.example.navitem5')}
+                </RouterLink>
+              </ServiceNavigationItem>
+            </ServiceNavigation>
           </ComponentExample>
         </Block>
       </SideNavLayout>

--- a/pages/components/sidenavigation.tsx
+++ b/pages/components/sidenavigation.tsx
@@ -187,100 +187,98 @@ const Page: NextPage = () => {
             {t('side_navigation_page.example.smallscreen.description')}
           </Paragraph>
 
-          <ComponentExample style={{ justifyContent: 'flex-start' }}>
-            <div style={{ width: '350px' }}>
-              <SideNavigation
-                heading={t('side_navigation_page.example.title')}
-                icon="piggyBank"
-                aria-label={t('side_navigation_page.example.arialabel')}
-                variant="smallScreen"
-                initiallyExpanded={false}
+          <ComponentExample variant="mobile_device">
+            <SideNavigation
+              heading={t('side_navigation_page.example.title')}
+              icon="piggyBank"
+              aria-label={t('side_navigation_page.example.arialabel')}
+              variant="smallScreen"
+              initiallyExpanded={false}
+            >
+              <SideNavigationItem
+                subLevel={1}
+                content={
+                  <RouterLink href="/" aria-current="location">
+                    {t('side_navigation_page.example.navitem1')}
+                  </RouterLink>
+                }
               >
                 <SideNavigationItem
-                  subLevel={1}
+                  subLevel={2}
                   content={
                     <RouterLink href="/" aria-current="location">
-                      {t('side_navigation_page.example.navitem1')}
+                      {t('side_navigation_page.example.navitem1-2-1')}
                     </RouterLink>
                   }
                 >
                   <SideNavigationItem
-                    subLevel={2}
-                    content={
-                      <RouterLink href="/" aria-current="location">
-                        {t('side_navigation_page.example.navitem1-2-1')}
-                      </RouterLink>
-                    }
-                  >
-                    <SideNavigationItem
-                      subLevel={3}
-                      content={
-                        <RouterLink href="/">
-                          {t('side_navigation_page.example.navitem1-2-1-1')}
-                        </RouterLink>
-                      }
-                    />
-                    <SideNavigationItem
-                      subLevel={3}
-                      selected
-                      content={
-                        <RouterLink href="/" aria-current="page">
-                          {t('side_navigation_page.example.navitem1-2-1-2')}
-                        </RouterLink>
-                      }
-                    />
-                    <SideNavigationItem
-                      subLevel={3}
-                      content={
-                        <RouterLink href="/">
-                          {t('side_navigation_page.example.navitem1-2-1-3')}
-                        </RouterLink>
-                      }
-                    />
-                  </SideNavigationItem>
-                  <SideNavigationItem
-                    subLevel={2}
+                    subLevel={3}
                     content={
                       <RouterLink href="/">
-                        {t('side_navigation_page.example.navitem1-2-2')}
+                        {t('side_navigation_page.example.navitem1-2-1-1')}
+                      </RouterLink>
+                    }
+                  />
+                  <SideNavigationItem
+                    subLevel={3}
+                    selected
+                    content={
+                      <RouterLink href="/" aria-current="page">
+                        {t('side_navigation_page.example.navitem1-2-1-2')}
+                      </RouterLink>
+                    }
+                  />
+                  <SideNavigationItem
+                    subLevel={3}
+                    content={
+                      <RouterLink href="/">
+                        {t('side_navigation_page.example.navitem1-2-1-3')}
                       </RouterLink>
                     }
                   />
                 </SideNavigationItem>
                 <SideNavigationItem
-                  subLevel={1}
+                  subLevel={2}
                   content={
-                    <RouterLink href="#">
-                      {t('side_navigation_page.example.navitem2')}
+                    <RouterLink href="/">
+                      {t('side_navigation_page.example.navitem1-2-2')}
                     </RouterLink>
                   }
                 />
-                <SideNavigationItem
-                  content={
-                    <RouterLink href="#">
-                      {t('side_navigation_page.example.navitem3')}
-                    </RouterLink>
-                  }
-                  subLevel={1}
-                />
-                <SideNavigationItem
-                  subLevel={1}
-                  content={
-                    <RouterLink href="#">
-                      {t('side_navigation_page.example.navitem4')}
-                    </RouterLink>
-                  }
-                />
-                <SideNavigationItem
-                  subLevel={1}
-                  content={
-                    <RouterLink href="#">
-                      {t('side_navigation_page.example.navitem5')}
-                    </RouterLink>
-                  }
-                />
-              </SideNavigation>
-            </div>
+              </SideNavigationItem>
+              <SideNavigationItem
+                subLevel={1}
+                content={
+                  <RouterLink href="#">
+                    {t('side_navigation_page.example.navitem2')}
+                  </RouterLink>
+                }
+              />
+              <SideNavigationItem
+                content={
+                  <RouterLink href="#">
+                    {t('side_navigation_page.example.navitem3')}
+                  </RouterLink>
+                }
+                subLevel={1}
+              />
+              <SideNavigationItem
+                subLevel={1}
+                content={
+                  <RouterLink href="#">
+                    {t('side_navigation_page.example.navitem4')}
+                  </RouterLink>
+                }
+              />
+              <SideNavigationItem
+                subLevel={1}
+                content={
+                  <RouterLink href="#">
+                    {t('side_navigation_page.example.navitem5')}
+                  </RouterLink>
+                }
+              />
+            </SideNavigation>
           </ComponentExample>
         </Block>
       </SideNavLayout>

--- a/pages/info/accessibility.tsx
+++ b/pages/info/accessibility.tsx
@@ -1,0 +1,96 @@
+import { NextPage } from 'next';
+import { useTranslation } from 'next-export-i18n';
+import Head from 'next/head';
+import {
+  Heading,
+  Block,
+  Text,
+  Paragraph,
+  ExternalLink,
+} from 'suomifi-ui-components';
+import SideNavLayout from '../../layouts/SideNavLayout/SideNavLayout';
+import { navItems } from '../../utils/info-sidenav';
+
+const StylesIndexPage: NextPage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Head>
+        <title>{t('main_nav.info')} | Suomi.fi Design System</title>
+      </Head>
+      <SideNavLayout
+        navItems={navItems}
+        navHeaderText={t('main_nav.info')}
+        navIcon="book"
+      >
+        <Heading variant="h1" className="mb-xl">
+          {t('info.accessibility')}
+        </Heading>
+        <Block mb="xl">
+          <Text variant="lead">{t('accessibility_page.ingress')}</Text>
+        </Block>
+        <Paragraph marginBottomSpacing="l">
+          {t('accessibility_page.paragraph_1')}
+        </Paragraph>
+        <Paragraph marginBottomSpacing="l">
+          {t('accessibility_page.paragraph_2')}
+        </Paragraph>
+        <Block mb="l">
+          <ExternalLink
+            href="https://www.finlex.fi/fi/laki/alkup/2019/20190306"
+            labelNewWindow={t('common.opens_in_a_new_tab')}
+          >
+            {t('accessibility_page.link_1')}
+          </ExternalLink>
+        </Block>
+        <Block mb="xl">
+          <ExternalLink
+            href="https://eur-lex.europa.eu/legal-content/FI/TXT/HTML/?uri=CELEX:32016L2102&from=FI"
+            labelNewWindow={t('common.opens_in_a_new_tab')}
+          >
+            {t('accessibility_page.link_2')}
+          </ExternalLink>
+        </Block>
+        <Block mb="l">
+          <ExternalLink
+            href="https://www.w3.org/Translations/WCAG21-fi/"
+            labelNewWindow={t('common.opens_in_a_new_tab')}
+          >
+            {t('accessibility_page.link_3')}
+          </ExternalLink>
+        </Block>
+        <Block>
+          <Heading variant="h2" className="mb-l">
+            {t('accessibility_page.multiple_factors.heading')}
+          </Heading>
+          <Paragraph marginBottomSpacing="l">
+            {t('accessibility_page.multiple_factors.paragraph_1')}
+          </Paragraph>
+          <Paragraph marginBottomSpacing="l">
+            {t('accessibility_page.multiple_factors.paragraph_2')}
+          </Paragraph>
+          <Paragraph marginBottomSpacing="l">
+            {t('accessibility_page.multiple_factors.paragraph_3')}
+          </Paragraph>
+          <Block mb="l">
+            <ul>
+              <li>{t('accessibility_page.multiple_factors.point_1')}</li>
+              <li>{t('accessibility_page.multiple_factors.point_2')}</li>
+              <li>{t('accessibility_page.multiple_factors.point_3')}</li>
+              <li>{t('accessibility_page.multiple_factors.point_4')}</li>
+            </ul>
+          </Block>
+          <ExternalLink
+            href="https://www.saavutettavuusvaatimukset.fi/"
+            labelNewWindow={t('common.opens_in_a_new_tab')}
+          >
+            {t('accessibility_page.multiple_factors.link')}
+          </ExternalLink>
+        </Block>
+      </SideNavLayout>
+    </>
+  );
+};
+
+export default StylesIndexPage;

--- a/pages/info/index.tsx
+++ b/pages/info/index.tsx
@@ -1,0 +1,72 @@
+import { NextPage } from 'next';
+import { useTranslation } from 'next-export-i18n';
+import Head from 'next/head';
+import {
+  Heading,
+  Block,
+  Text,
+  Paragraph,
+  ExternalLink,
+} from 'suomifi-ui-components';
+import SideNavLayout from '../../layouts/SideNavLayout/SideNavLayout';
+import { navItems } from '../../utils/info-sidenav';
+
+const StylesIndexPage: NextPage = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Head>
+        <title>{t('main_nav.info')} | Suomi.fi Design System</title>
+      </Head>
+      <SideNavLayout
+        navItems={navItems}
+        navHeaderText={t('main_nav.info')}
+        navIcon="book"
+      >
+        <Heading variant="h1" className="mb-xl">
+          {t('info.info')}
+        </Heading>
+        <Block mb="xl">
+          <Text variant="lead">{t('info_main_page.ingress')}</Text>
+        </Block>
+        <Block mb="xl">
+          <Heading variant="h2" className="mb-l">
+            {t('info_main_page.ux_and_accessibility.heading')}
+          </Heading>
+          <Paragraph marginBottomSpacing="l">
+            {t('info_main_page.ux_and_accessibility.paragraph_1')}
+          </Paragraph>
+          <Paragraph>
+            {t('info_main_page.ux_and_accessibility.paragraph_2')}
+          </Paragraph>
+        </Block>
+        <Block mb="xl">
+          <Heading variant="h2" className="mb-l">
+            {t('info_main_page.brand.heading')}
+          </Heading>
+          <Paragraph marginBottomSpacing="l">
+            {t('info_main_page.brand.paragraph_1')}
+          </Paragraph>
+          <Paragraph>{t('info_main_page.brand.paragraph_2')}</Paragraph>
+        </Block>
+        <Block mb="xl">
+          <Heading variant="h2" className="mb-l">
+            {t('info_main_page.ask_and_comment.heading')}
+          </Heading>
+          <Paragraph marginBottomSpacing="l">
+            {t('info_main_page.ask_and_comment.paragraph_1')}
+          </Paragraph>
+          <ExternalLink
+            href="https://github.com/vrk-kpa/suomifi-ui-components"
+            labelNewWindow={t('common.opens_in_a_new_tab')}
+          >
+            {t('info_main_page.ask_and_comment.link_text')}
+          </ExternalLink>
+        </Block>
+      </SideNavLayout>
+    </>
+  );
+};
+
+export default StylesIndexPage;

--- a/pages/styles/colors.tsx
+++ b/pages/styles/colors.tsx
@@ -39,13 +39,50 @@ const colors: any = Object.entries(colorTokens).reduce(
   },
   {},
 );
-
+const brandColors: ColorItem[] | undefined[] = [colors.brandBase];
 const textColors: ColorItem[] | undefined[] = [
   colors.blackBase,
   colors.depthBase,
   colors.depthDark2,
 ];
-const brandColors: ColorItem[] | undefined[] = [colors.brandBase];
+const functionalColors: ColorItem[] | undefined[] = [
+  colors.highlightBase,
+  colors.highlightLight1,
+  colors.highlightLight2,
+  colors.highlightLight3,
+  colors.highlightDark1,
+  colors.depthBase,
+  colors.accentSecondary,
+  colors.accentTertiaryDark1,
+];
+const iconColors: ColorItem[] | undefined[] = [
+  colors.depthBase,
+  colors.accentBase,
+  colors.highlightBase,
+  colors.depthDark1,
+];
+const borderColors: ColorItem[] | undefined[] = [
+  colors.whiteBase,
+  colors.depthLight3,
+  colors.depthLight1,
+  colors.highlightLight2,
+  colors.highlightLight3,
+  colors.highlightLight4,
+  colors.depthSecondary,
+];
+const trafficlightColors: ColorItem[] | undefined[] = [
+  colors.successBase,
+  colors.successSecondary,
+  colors.warningBase,
+  colors.alertBase,
+  colors.alertLight1,
+];
+const accentColors: ColorItem[] | undefined[] = [
+  colors.accentBase,
+  colors.accentSecondary,
+  colors.accentSecondaryLight1,
+  colors.accentTertiary,
+];
 
 const ColorsPage: NextPage = () => {
   const { t } = useTranslation();
@@ -87,6 +124,16 @@ const ColorsPage: NextPage = () => {
             </ExternalLink>
           </Block>
         </Block>
+
+        <Heading variant="h2" className="mb-l">
+          {t('colors.brand.heading')}
+        </Heading>
+        <Paragraph>{t('colors.brand.paragraph')}</Paragraph>
+        <Block my="l">
+          <ColorShowcase colors={brandColors}></ColorShowcase>
+        </Block>
+        <Divider />
+
         <Heading variant="h2" className="mb-l">
           {t('colors.texts.heading')}
         </Heading>
@@ -95,12 +142,49 @@ const ColorsPage: NextPage = () => {
           <ColorShowcase colors={textColors}></ColorShowcase>
         </Block>
         <Divider />
+
         <Heading variant="h2" className="mb-l">
-          {t('colors.brand.heading')}
+          {t('colors.functionals.heading')}
         </Heading>
-        <Paragraph>{t('colors.brand.paragraph')}</Paragraph>
-        <Block my="l">
-          <ColorShowcase colors={brandColors}></ColorShowcase>
+        <Paragraph>{t('colors.functionals.paragraph')}</Paragraph>
+        <Block mt="l">
+          <ColorShowcase colors={functionalColors}></ColorShowcase>
+        </Block>
+        <Divider />
+
+        <Heading variant="h2" className="mb-l">
+          {t('colors.icons.heading')}
+        </Heading>
+        <Paragraph>{t('colors.icons.paragraph')}</Paragraph>
+        <Block mt="l">
+          <ColorShowcase colors={iconColors}></ColorShowcase>
+        </Block>
+        <Divider />
+
+        <Heading variant="h2" className="mb-l">
+          {t('colors.borders.heading')}
+        </Heading>
+        <Paragraph>{t('colors.borders.paragraph')}</Paragraph>
+        <Block mt="l">
+          <ColorShowcase colors={borderColors}></ColorShowcase>
+        </Block>
+        <Divider />
+
+        <Heading variant="h2" className="mb-l">
+          {t('colors.trafficlights.heading')}
+        </Heading>
+        <Paragraph>{t('colors.trafficlights.paragraph')}</Paragraph>
+        <Block mt="l">
+          <ColorShowcase colors={trafficlightColors}></ColorShowcase>
+        </Block>
+        <Divider />
+
+        <Heading variant="h2" className="mb-l">
+          {t('colors.accents.heading')}
+        </Heading>
+        <Paragraph>{t('colors.accents.paragraph')}</Paragraph>
+        <Block mt="l">
+          <ColorShowcase colors={accentColors}></ColorShowcase>
         </Block>
       </SideNavLayout>
     </>

--- a/pages/styles/icons.tsx
+++ b/pages/styles/icons.tsx
@@ -1,7 +1,7 @@
 import { NextPage } from 'next';
 import { useTranslation } from 'next-export-i18n';
 import Head from 'next/head';
-import { Heading, Block, Text } from 'suomifi-ui-components';
+import { Heading, Block, Text, RouterLink } from 'suomifi-ui-components';
 
 import SideNavLayout from '../../layouts/SideNavLayout/SideNavLayout';
 import { navItems } from '../../utils/styles-sidenav';
@@ -9,6 +9,7 @@ import { IconCategories } from '../../interfaces/interfaces';
 
 import { baseIcons, illustrativeIcons, doctypeIcons } from 'suomifi-icons';
 import IconShowcase from '../../components/IconShowcase/IconShowcase';
+import Link from 'next/link';
 
 const IconsPage: NextPage = () => {
   const { t } = useTranslation();
@@ -55,6 +56,11 @@ const IconsPage: NextPage = () => {
         </Heading>
         <Block my="l">
           <Text variant="lead">{t('icons.ingress')}</Text>
+        </Block>
+        <Block mb="l">
+          <Link href="/components/icon" passHref>
+            <RouterLink>{t('icons.icon_component_link_text')}</RouterLink>
+          </Link>
         </Block>
         <IconShowcase iconCategories={iconCategories} />
       </SideNavLayout>

--- a/pages/styles/spacing.tsx
+++ b/pages/styles/spacing.tsx
@@ -1,7 +1,9 @@
 import { NextPage } from 'next';
 import { useTranslation } from 'next-export-i18n';
 import Head from 'next/head';
-import { Heading, Block, Text } from 'suomifi-ui-components';
+import { suomifiDesignTokens } from 'suomifi-design-tokens';
+import { Heading, Block, Text, Paragraph } from 'suomifi-ui-components';
+import ComponentExample from '../../components/ComponentExample/ComponentExample';
 import SpacingShowcase from '../../components/SpacingShowcase/SpacingShowcase';
 import SideNavLayout from '../../layouts/SideNavLayout/SideNavLayout';
 import { navItems } from '../../utils/styles-sidenav';
@@ -22,10 +24,54 @@ const StylesIndexPage: NextPage = () => {
         <Heading variant="h1" className="mb-xl">
           {t('spacing.heading')}
         </Heading>
-        <Block mb="l">
+        <Block mb="xl">
           <Text variant="lead">{t('spacing.ingress')}</Text>
         </Block>
-        <SpacingShowcase />
+        <Paragraph marginBottomSpacing="xl">
+          {t('spacing.paragraph_1')}
+        </Paragraph>
+        <Block mb="xxxl">
+          <SpacingShowcase values="normal" />
+        </Block>
+        <Paragraph marginBottomSpacing="l">
+          {t('spacing.paragraph_2')}
+        </Paragraph>
+        <Block mb="xxl">
+          <ComponentExample
+            filterPropsInExample={['style', 'className']}
+            style={{ flexDirection: 'column' }}
+          >
+            <Block
+              className="flex justify-center align-center"
+              style={{
+                border: `1px dashed ${suomifiDesignTokens.colors.depthLight1}`,
+              }}
+              pt="xxl"
+              pb="m"
+              pl="s"
+              pr="xl"
+            >
+              {t('spacing.block_text_1')}
+            </Block>
+            <Block
+              className="flex justify-center align-center"
+              style={{
+                border: `1px dashed ${suomifiDesignTokens.colors.depthLight1}`,
+              }}
+              padding="s"
+              mt="xl"
+            >
+              {t('spacing.block_text_2')}
+            </Block>
+          </ComponentExample>
+        </Block>
+        <Block mb="l">
+          <Heading variant="h2">{t('spacing.inset_heading')}</Heading>
+        </Block>
+        <Paragraph marginBottomSpacing="xl">
+          {t('spacing.paragraph_3')}
+        </Paragraph>
+        <SpacingShowcase values="inset" />
       </SideNavLayout>
     </>
   );

--- a/styles/_utilities.scss
+++ b/styles/_utilities.scss
@@ -55,6 +55,9 @@ $spacings:  (
   &.align-center {
     align-items: center;
   }
+  &.justify-center {
+    justify-content: center;
+  }
 }
 
 .w-100 {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600&display=swap');
+// @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600&display=swap');
 @import 'suomifi-ui-components/dist/main.css';
 @import '~suomifi-design-tokens/dist/tokens';
 @import './_utilities';

--- a/utils/complicatedCodeExamples.ts
+++ b/utils/complicatedCodeExamples.ts
@@ -39,8 +39,7 @@ export const Example = () => (
       padding: suomifiDesignTokens.spacing.s,
       background: suomifiDesignTokens.colors.highlightBase,
       fontSize:
-        suomifiDesignTokens.values.typography.bodyText.fontSize
-          .value +
+        suomifiDesignTokens.values.typography.bodyText.fontSize.value +
         suomifiDesignTokens.values.typography.bodyText.fontSize.unit,
       color: suomifiDesignTokens.colors.whiteBase,
     }}

--- a/utils/info-sidenav.ts
+++ b/utils/info-sidenav.ts
@@ -1,0 +1,15 @@
+import { NavItem } from "../interfaces/interfaces";
+
+// TODO: Figure out a way to do this based on the selected language, not always 'fi'
+import translations from '../i18n/translations.fi.json';
+
+export const navItems: NavItem[] = [
+    {
+        title: translations.info.info,
+        path: "/info",
+    },
+    {
+        title: translations.info.accessibility,
+        path: "/info/accessibility",
+    }
+]

--- a/utils/styles-sidenav.ts
+++ b/utils/styles-sidenav.ts
@@ -9,15 +9,15 @@ export const navItems: NavItem[] = [
         path: "/styles",
     },
     {
-        title: translations.styles.colors,
-        path: "/styles/colors",
-    },
-    {
         title: translations.styles.icons,
         path: "/styles/icons",
     },
     {
         title: translations.styles.spacing,
         path: "/styles/spacing",
+    },
+    {
+        title: translations.styles.colors,
+        path: "/styles/colors",
     },
 ]


### PR DESCRIPTION
This PR adds content to the following pages

- /styles
- /styles/colors
- /styles/icons
- /styles/spacing
- /info
- /info/accessibility

For now at least, omitted the old "kehittäjälle" and "suunnittelijalle" pages